### PR TITLE
Fix for index out of bounds exception keycloak 25 issue 214

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -67,7 +67,7 @@ class ResourceExtractor {
             List<String> matchedURIs = uriInfo.getMatchedURIs();
             StringBuilder sb = new StringBuilder();
 
-            if (URI_METRICS_FILTER != null && URI_METRICS_FILTER.length() != 0) {
+            if (URI_METRICS_FILTER != null && URI_METRICS_FILTER.length() != 0 && !matchedURIs.isEmpty()) {
                 String[] filter = URI_METRICS_FILTER.split(",");
 
                 for (int i = 0; i < filter.length; i++) {

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -63,11 +63,11 @@ class ResourceExtractor {
      * @return The resource uri.
      */
     static String getURI(UriInfo uriInfo) {
-        if (URI_METRICS_ENABLED) {
+        if (URI_METRICS_ENABLED && !matchedURIs.isEmpty()) {
             List<String> matchedURIs = uriInfo.getMatchedURIs();
             StringBuilder sb = new StringBuilder();
 
-            if (URI_METRICS_FILTER != null && URI_METRICS_FILTER.length() != 0 && !matchedURIs.isEmpty()) {
+            if (URI_METRICS_FILTER != null && URI_METRICS_FILTER.length() != 0) {
                 String[] filter = URI_METRICS_FILTER.split(",");
 
                 for (int i = 0; i < filter.length; i++) {


### PR DESCRIPTION
should fix IndexOutOfBoundsException with keycloak 25

## Motivation
https://github.com/aerogear/keycloak-metrics-spi/issues/214

## What
Adding a check that `matchedURIs` is not an empty list to [ResourceExtractor.getURI](https://github.com/aerogear/keycloak-metrics-spi/blob/master/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java#L65)  

## Why
Currently when using version keycloak-metrics-spi-6.0.0.jar with Keycloak 25 when a call comes into a URI that doesn't have a matching resource `uriInfo.getMatchedURIs` returns an empty list see https://jakarta.ee/specifications/platform/9/apidocs/jakarta/ws/rs/core/uriinfo#getMatchedURIs--

## How
Adding a check to ensure that `get(0)` is not called on the empty list

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 

